### PR TITLE
Switch to static shortcut endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,26 @@ Le indicazioni qui riportate facevano riferimento a problemi ora risolti (doppio
 manifest, `start_url` errato e commenti dei test). Il progetto è già aggiornato
 di conseguenza.
 
+
+## Integrazione Comandi Rapidi iOS
+
+Per ottenere l'orario di uscita tramite un comando rapido senza server esterni è disponibile la pagina `shortcut.html`.
+Esempi di richiesta:
+
+```
+https://<sito>/mplus/shortcut.html?ora=08:30&tipo=corta
+https://<sito>/mplus/shortcut.html?ora=08:30&tipo=corta&paragrafo=1
+```
+
+Parametri:
+- `ora` (obbligatorio) nel formato `HH:MM`.
+- `tipo` opzionale (`corta` o `lunga`, default `corta`).
+- `paragrafo=1` restituisce anche il testo di suggerimento.
+
+### Esempio di Comando Rapido
+
+1. Apri l'app **Comandi** su iOS e crea un nuovo comando.
+2. Aggiungi **Chiedi testo** per l'orario di ingresso.
+3. Inserisci **Ottieni contenuti da URL** con l'indirizzo `https://<sito>/mplus/shortcut.html?ora=[Risultato di Chiedi testo]&tipo=corta`.
+4. (Facoltativo) aggiungi `&paragrafo=1` per ottenere anche il suggerimento.
+5. Termina con **Mostra risultato** per visualizzare il testo restituito.

--- a/service-worker.js
+++ b/service-worker.js
@@ -7,6 +7,8 @@ const ASSETS_TO_CACHE = [
   `${CACHE_PREFIX}/index.html`,
   `${CACHE_PREFIX}/style.css`,
   `${CACHE_PREFIX}/script.js`,
+  `${CACHE_PREFIX}/shortcut.html`,
+  `${CACHE_PREFIX}/shortcut.js`,
   `${CACHE_PREFIX}/manifest.json`,
   `${CACHE_PREFIX}/offline.html`,
   `${CACHE_PREFIX}/favicon.ico`,

--- a/shortcut.html
+++ b/shortcut.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MPLUS Shortcut</title>
+</head>
+<body>
+<script src="shortcut.js"></script>
+</body>
+</html>

--- a/shortcut.js
+++ b/shortcut.js
@@ -1,0 +1,92 @@
+(function() {
+  function timeToMinutes(timeStr) {
+    const [h, m] = timeStr.split(':').map(Number);
+    return h * 60 + m;
+  }
+
+  function minutesToTime(mins) {
+    const h = Math.floor(mins / 60);
+    const m = mins % 60;
+    return h.toString().padStart(2, '0') + ':' + m.toString().padStart(2, '0');
+  }
+
+  function formatEFFRECACC(oreEff, acc) {
+    const h = Math.floor(oreEff / 60);
+    const m = oreEff % 60;
+    const effStr = (h > 0 ? h + 'h' : '') + (m > 0 ? m + 'm' : '');
+    const parts = [`EFF ${effStr}`];
+    if (acc > 0) parts.push(`ACC ${acc} min`);
+    return parts.length ? '(' + parts.join(', ') + ')' : '';
+  }
+
+  function calcolaGiornata(tipo, IN1) {
+    const pausa = 30;
+    const ingresso = Math.max(IN1, 465); // minimo 07:45
+    const durata_teorica = tipo === 'corta' ? 360 : 540;
+    const uscita_bp = ingresso + pausa + 361;
+
+    let accumulo_dichiarato = tipo === 'corta' ? 20 : 0;
+    const ritardo = Math.max(0, IN1 - 540);
+    if (tipo === 'corta') accumulo_dichiarato += ritardo;
+
+    const max_totale = 29;
+    const accumulo_effettivo = Math.min(accumulo_dichiarato, max_totale);
+    const target_eff = 360 + accumulo_effettivo;
+    let uscita_strategica = ingresso + pausa + target_eff;
+    let ore_eff_strategica = target_eff;
+
+    let suggerimento = '';
+
+    if (tipo === 'corta') {
+      if (uscita_strategica > 1170) {
+        uscita_strategica = 1170;
+        ore_eff_strategica = uscita_strategica - ingresso - pausa;
+        const accumulo = Math.max(0, ore_eff_strategica - durata_teorica);
+        suggerimento = `⚠️ Chiusura 19:30: accumulo max ${accumulo} min.`;
+      } else if (accumulo_dichiarato > max_totale) {
+        suggerimento = '⚠️ Massimo 29 min raggiunto, accumulo ridotto.';
+      } else {
+        const ecc = ore_eff_strategica - durata_teorica;
+        if (ecc > 0) {
+          suggerimento = `⏱️ Esci alle ${minutesToTime(uscita_strategica)} per +${ecc} min.`;
+        } else {
+          suggerimento = '🍽️ Pausa di 30 min. Buono pasto ok.';
+        }
+      }
+    } else {
+      const uscita_normale = ingresso + pausa + durata_teorica;
+      uscita_strategica = Math.min(uscita_normale - 30, 1170);
+      ore_eff_strategica = uscita_strategica - ingresso - pausa;
+
+      if (uscita_normale > 1170 || uscita_bp >= 1170) {
+        suggerimento = '⚠️ Chiusura 19:30: pianifica un recupero.';
+      } else if (ore_eff_strategica >= 510) {
+        suggerimento = `↪️ Uscita normale ${minutesToTime(uscita_normale)} se vuoi evitare anticipo.`;
+      } else {
+        suggerimento = '🍽️ Pausa di 30 min. Buono pasto ok.';
+      }
+    }
+
+    const ore_eff_bp = uscita_bp - ingresso - pausa;
+
+    return {
+      uscita_stimata: minutesToTime(uscita_bp) + ' ' + formatEFFRECACC(ore_eff_bp, 0),
+      uscita_strategica: minutesToTime(uscita_strategica) + ' ' + formatEFFRECACC(ore_eff_strategica, Math.max(0, ore_eff_strategica - durata_teorica)),
+      suggerimento
+    };
+  }
+
+  const params = new URLSearchParams(location.search);
+  const ora = params.get('ora');
+  const tipo = params.get('tipo') === 'lunga' ? 'lunga' : 'corta';
+  const paragrafo = params.has('paragrafo');
+
+  if (!ora || !/^\d{2}:\d{2}$/.test(ora)) {
+    document.body.textContent = 'Parametro "ora" mancante o non valido (HH:MM)';
+    return;
+  }
+
+  const result = calcolaGiornata(tipo, timeToMinutes(ora));
+  const output = paragrafo ? `Uscita strategica: ${result.uscita_strategica}. ${result.suggerimento}` : result.uscita_strategica;
+  document.body.textContent = output;
+})();


### PR DESCRIPTION
## Summary
- revert API server commit
- add static `shortcut.html` + `shortcut.js` for iOS Shortcuts
- document new usage in README
- cache shortcut files in `service-worker.js`

## Testing
- *No tests defined; manual review only*

------
https://chatgpt.com/codex/tasks/task_e_685b9f440160832a80dba2ff62bdeadd