### PR TITLE
Add quick endpoint for iOS shortcuts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Indicazioni per gli sviluppatori
+
+Questo repository contiene una piccola applicazione PWA. Le linee guida per le modifiche sono:
+
+- Il codice JavaScript utilizza indentazione di 2 spazi.
+- Ogni nuova pagina o asset deve essere aggiunto all'elenco `ASSETS_TO_CACHE` di `service-worker.js`.
+- La documentazione principale è `README.md` ed è redatta in italiano. Ogni nuova funzionalità deve essere descritta in questo file.
+- Non sono presenti test automatici obbligatori.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ MPLUS è una piccola applicazione web (PWA) per il calcolo dell'orario di uscita
 - **service-worker.js**: caching delle risorse per l'utilizzo offline.
 - **manifest.json**: definizione del manifest PWA (icone, colori, `start_url`, ecc.).
 - **offline.html**: pagina visualizzata in assenza di connettività.
+- **quick.html**: endpoint minimale per integrazione con Comandi Rapidi di iOS.
 
 ## Funzionamento Principale
 
@@ -34,6 +35,18 @@ Alla fine di `script.js` sono presenti tre funzioni di test (`testCalcolaBP`, `t
 ## Esecuzione Locale
 
 Non sono richiesti ambienti di build particolari. È sufficiente un server statico (o l'apertura diretta di `index.html`) per utilizzare l'applicazione. Per l'installazione su dispositivi mobili, assicurarsi che il file `manifest.json` e il Service Worker siano correttamente serviti.
+
+## Integrazione con Comandi Rapidi iOS
+
+È possibile interrogare il sito tramite l'URL `quick.html` fornendo i parametri:
+
+- `ora` (es. `08:30`)
+- `tipo` (`corta` o `lunga`, opzionale, predefinito `corta`)
+- `out` (`time` per ottenere solo l'uscita strategica oppure `all` per l'intero paragrafo)
+
+Esempio: `https://stocabbo.github.io/mplus/quick.html?ora=08:30&out=all`
+
+Il contenuto restituito è testo semplice, ideale per essere letto da un Comando Rapido.
 
 ## Note Aggiuntive
 

--- a/quick.html
+++ b/quick.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8">
+  <title>MPLUS Quick</title>
+</head>
+<body>
+  <pre id="result">In elaborazione...</pre>
+  <script src="script.js"></script>
+  <script>
+  (function(){
+    const params = new URLSearchParams(window.location.search);
+    const ora = params.get('ora');
+    const tipo = params.get('tipo') || 'corta';
+    const out = params.get('out') || 'time';
+
+    if(!ora){
+      document.getElementById('result').innerText = 'Parametro "ora" mancante. Esempio: ?ora=08:30&tipo=corta&out=time';
+      return;
+    }
+    const res = calcolaGiornata(tipo, timeToMinutes(ora));
+    let txt = '';
+    if(out === 'all'){
+      txt = 'Uscita per BP: ' + res.uscita_stimata + '\n' +
+            'Uscita strategica: ' + res.uscita_strategica + '\n' +
+            res.suggerimento;
+    } else {
+      txt = res.uscita_strategica;
+    }
+    document.body.innerText = txt;
+  })();
+  </script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -124,23 +124,27 @@ function aggiornaRisultati() {
   if (oraStrategica) startCountdown(oraStrategica);
 }
 
-document.getElementById('ora_ingresso').addEventListener('input', aggiornaRisultati);
-document.getElementById('toggle_giornata').addEventListener('change', aggiornaRisultati);
-window.addEventListener('DOMContentLoaded', () => {
-  requestNotificationPermission();
-  const urlParams = new URLSearchParams(window.location.search);
-  const paramOra = urlParams.get("ora");
-  const oraInput = document.getElementById('ora_ingresso');
-  if (paramOra && /^\d{2}:\d{2}$/.test(paramOra)) {
-    oraInput.value = paramOra;
-  } else {
-    const now = new Date();
-    const hh = String(now.getHours()).padStart(2, '0');
-    const mm = String(now.getMinutes()).padStart(2, '0');
-    oraInput.value = `${hh}:${mm}`;
-  }
-  aggiornaRisultati();
-});
+const ingressoEl = document.getElementById('ora_ingresso');
+const toggleEl = document.getElementById('toggle_giornata');
+if (ingressoEl && toggleEl) {
+  ingressoEl.addEventListener('input', aggiornaRisultati);
+  toggleEl.addEventListener('change', aggiornaRisultati);
+  window.addEventListener('DOMContentLoaded', () => {
+    requestNotificationPermission();
+    const urlParams = new URLSearchParams(window.location.search);
+    const paramOra = urlParams.get("ora");
+    const oraInput = document.getElementById('ora_ingresso');
+    if (paramOra && /^\d{2}:\d{2}$/.test(paramOra)) {
+      oraInput.value = paramOra;
+    } else {
+      const now = new Date();
+      const hh = String(now.getHours()).padStart(2, '0');
+      const mm = String(now.getMinutes()).padStart(2, '0');
+      oraInput.value = `${hh}:${mm}`;
+    }
+    aggiornaRisultati();
+  });
+}
 
 let countdownInterval;
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -9,6 +9,7 @@ const ASSETS_TO_CACHE = [
   `${CACHE_PREFIX}/script.js`,
   `${CACHE_PREFIX}/manifest.json`,
   `${CACHE_PREFIX}/offline.html`,
+  `${CACHE_PREFIX}/quick.html`,
   `${CACHE_PREFIX}/favicon.ico`,
   `${CACHE_PREFIX}/icon-192.png`,
   `${CACHE_PREFIX}/icon-512.png`


### PR DESCRIPTION
## Summary
- add a root AGENTS file with contribution guidelines
- add `quick.html` endpoint to provide plain-text results for iOS Shortcuts
- cache new file via service worker
- guard DOM lookups in `script.js`
- document the new feature in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bb61066d4832ab2625067818f6b8b