### PR TITLE
Handle single digit hour query

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ## Panoramica
 
+
 MPLUS è una piccola applicazione web (PWA) per il calcolo dell'orario di uscita ottimale dal lavoro. L'interfaccia è in italiano e include una modalità "giornata corta" e "giornata lunga". Al caricamento l'app può operare offline grazie al Service Worker e al manifest che permette l'installazione su dispositivi mobili.
 
 ## Struttura del progetto
@@ -38,9 +39,10 @@ Non sono richiesti ambienti di build particolari. È sufficiente un server stati
 
 ## Integrazione con Comandi Rapidi iOS
 
+
 È possibile interrogare il sito tramite l'URL `quick.html` fornendo i parametri:
 
-- `ora` (es. `08:30`)
+- `ora` (es. `08:30`). È consentito omettere lo zero iniziale (es. `8:30`)
 - `tipo` (`corta` o `lunga`, opzionale, predefinito `corta`)
 - `out` (`time` per ottenere solo l'uscita strategica oppure `all` per l'intero paragrafo)
 

--- a/script.js
+++ b/script.js
@@ -134,8 +134,9 @@ if (ingressoEl && toggleEl) {
     const urlParams = new URLSearchParams(window.location.search);
     const paramOra = urlParams.get("ora");
     const oraInput = document.getElementById('ora_ingresso');
-    if (paramOra && /^\d{2}:\d{2}$/.test(paramOra)) {
-      oraInput.value = paramOra;
+    if (paramOra && /^\d{1,2}:\d{2}$/.test(paramOra)) {
+      const [h, m] = paramOra.split(":");
+      oraInput.value = h.padStart(2, "0") + ":" + m;
     } else {
       const now = new Date();
       const hh = String(now.getHours()).padStart(2, '0');


### PR DESCRIPTION
## Summary
- allow single-digit `ora` parameter and normalize to `HH:MM`
- document this possibility in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bdc15f5e4832ab5bada2f8fd0a89c