### PR TITLE
Fix lunch break rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ La funzione `calcolaGiornata(tipo, IN1)` riceve il tipo di giornata ("corta" o "
 
 - `uscita_stimata`: orario minimo per ottenere il buono pasto e relativo accumulo/recupero.
 - `uscita_strategica`: orario consigliato per ottenere il massimo accumulo nel rispetto dei limiti.
-- `pausa_inizio` e `pausa_fine`: orari suggeriti per la pausa pranzo.
+- `pausa_inizio` e `pausa_fine`: orario pausa suggerita (inizio e fine).
 - `suggerimento`: messaggio per l'utente.
 
 Il file `script.js` gestisce inoltre l'aggiornamento dinamico dei risultati e il countdown fino all'uscita strategica con eventuali notifiche.
@@ -34,9 +34,17 @@ Il `service-worker.js` memorizza in cache le risorse di base. Se una richiesta f
 
 Attraverso l'icona a forma di ingranaggio è possibile definire:
 
-- i minuti di extra da accumulare nella giornata corta (default 20);
-- i minuti di anticipo/recupero nella giornata lunga (default 30);
-- la durata minima della pausa pranzo (default 30).
+- i minuti di extra da accumulare nella giornata corta (default 20, max 30);
+- i minuti di anticipo/recupero nella giornata lunga (default 30, max 30);
+- la durata minima della pausa pranzo (default 30, valori ammessi 20-120).
+
+## Regole di Calcolo
+
+- L'orario di ingresso conteggiato parte dalle 7:45; se si entra prima, i minuti precedenti non vengono considerati.
+- L'uscita massima consentita è alle 19:30.
+- Se la pausa pranzo è inferiore a 30 minuti, ai fini del computo vengono comunque sottratti 30 minuti di lavoro.
+- L'accumulo massimo ottenibile è 30 minuti; valori superiori vengono ridotti e segnalati.
+- Per maturare il buono pasto servono almeno 20 minuti di pausa nell'arco di 6h1min di lavoro effettivo e almeno 30 minuti di attività dopo il rientro.
 
 Oltre ai calcoli di uscita, l'app indica l'orario consigliato per la pausa pranzo e per il rientro.
 

--- a/index.html
+++ b/index.html
@@ -42,13 +42,13 @@
     <div class="settings-content">
       <h2>Impostazioni</h2>
       <label>Extra giornata corta (min)
-        <input type="number" id="opt_extra_corta" min="0">
+        <input type="number" id="opt_extra_corta" min="0" max="30">
       </label>
       <label>Recupero giornata lunga (min)
-        <input type="number" id="opt_recupero_lunga" min="0">
+        <input type="number" id="opt_recupero_lunga" min="0" max="30">
       </label>
       <label>Pausa pranzo (min)
-        <input type="number" id="opt_pausa" min="0">
+        <input type="number" id="opt_pausa" min="20" max="120">
       </label>
       <button id="save_settings">Salva</button>
     </div>

--- a/script.js
+++ b/script.js
@@ -7,12 +7,19 @@ const defaultSettings = {
 
 function loadSettings() {
   const saved = localStorage.getItem('mplus_settings');
-  return saved ? { ...defaultSettings, ...JSON.parse(saved) } : { ...defaultSettings };
+  const obj = saved ? { ...defaultSettings, ...JSON.parse(saved) } : { ...defaultSettings };
+  obj.pausaMinima = Math.min(Math.max(obj.pausaMinima, 20), 120);
+  obj.extraCorta = Math.min(Math.max(obj.extraCorta, 0), 30);
+  obj.recuperoLunga = Math.min(Math.max(obj.recuperoLunga, 0), 30);
+  return obj;
 }
 
 let settings = loadSettings();
 
 function saveSettings() {
+  settings.pausaMinima = Math.min(Math.max(settings.pausaMinima, 20), 120);
+  settings.extraCorta = Math.min(Math.max(settings.extraCorta, 0), 30);
+  settings.recuperoLunga = Math.min(Math.max(settings.recuperoLunga, 0), 30);
   localStorage.setItem('mplus_settings', JSON.stringify(settings));
 }
 
@@ -43,19 +50,22 @@ function formatEFFRECACC(oreEff, acc) {
 
 function calcolaGiornata(tipo, IN1) {
   const pausa = settings.pausaMinima;
+  const pausaEff = Math.max(pausa, 30);
+  const pausaBP = Math.max(pausa, 20);
   const ingresso = Math.max(IN1, 465); // minimo 07:45
   const durata_teorica = tipo === "corta" ? 360 : 540;
-  const uscita_bp = ingresso + pausa + 361;
+  let uscita_bp = ingresso + pausaBP + 361;
+  uscita_bp = Math.min(uscita_bp, 1170);
   const { inizio: pausaStart, fine: pausaEnd } = calcolaPausa(ingresso);
 
   let accumulo_dichiarato = tipo === "corta" ? settings.extraCorta : 0;
   const ritardo = Math.max(0, IN1 - 540);
   if (tipo === "corta") accumulo_dichiarato += ritardo;
 
-  const max_totale = 29;
+  const max_totale = 30;
   const accumulo_effettivo = Math.min(accumulo_dichiarato, max_totale);
   const target_eff = 360 + accumulo_effettivo;
-  let uscita_strategica = ingresso + pausa + target_eff;
+  let uscita_strategica = ingresso + pausaEff + target_eff;
   let ore_eff_strategica = target_eff;
 
   let stato = "green";
@@ -65,7 +75,7 @@ function calcolaGiornata(tipo, IN1) {
   if (tipo === "corta") {
     if (uscita_strategica > 1170) {
       uscita_strategica = 1170;
-      ore_eff_strategica = uscita_strategica - ingresso - pausa;
+      ore_eff_strategica = uscita_strategica - ingresso - pausaEff;
       const accumulo = Math.max(0, ore_eff_strategica - durata_teorica);
         stato = "red";
         badge = "⚠️ 19:30";
@@ -74,7 +84,7 @@ function calcolaGiornata(tipo, IN1) {
       const ecc = ore_eff_strategica - durata_teorica;
         stato = "yellow";
         badge = `↪︎ +${ecc} min`;
-        suggerimento = "⚠️ Massimo 29 min raggiunto, accumulo ridotto.";
+        suggerimento = "⚠️ Massimo 30 min raggiunto, accumulo ridotto.";
     } else {
       const ecc = ore_eff_strategica - durata_teorica;
       if (ecc > 0) {
@@ -82,13 +92,14 @@ function calcolaGiornata(tipo, IN1) {
         badge = `↪︎ +${ecc} min`;
         suggerimento = `⏱️ Esci alle ${minutesToTime(uscita_strategica)} per +${ecc} min.`;
       } else {
-        suggerimento = `🍽️ Pausa di ${settings.pausaMinima} min. Buono pasto ok.`;
+        const bpMsg = settings.pausaMinima >= 20 ? 'Buono pasto ok.' : 'Pausa troppo breve per BP.';
+        suggerimento = `🍽️ Pausa di ${settings.pausaMinima} min. ${bpMsg}`;
       }
     }
   } else {
-    const uscita_normale = ingresso + pausa + durata_teorica;
+    const uscita_normale = ingresso + pausaEff + durata_teorica;
     uscita_strategica = Math.min(uscita_normale - settings.recuperoLunga, 1170);
-    ore_eff_strategica = uscita_strategica - ingresso - pausa;
+    ore_eff_strategica = uscita_strategica - ingresso - pausaEff;
 
     if (uscita_normale > 1170) {
         stato = "red";
@@ -103,11 +114,12 @@ function calcolaGiornata(tipo, IN1) {
         badge = `↪︎ -${settings.recuperoLunga} min`;
         suggerimento = `↪️ Uscita normale ${minutesToTime(uscita_normale)} se vuoi evitare anticipo.`;
     } else {
-        suggerimento = `🍽️ Pausa di ${settings.pausaMinima} min. Buono pasto ok.`;
+        const bpMsg = settings.pausaMinima >= 20 ? 'Buono pasto ok.' : 'Pausa troppo breve per BP.';
+        suggerimento = `🍽️ Pausa di ${settings.pausaMinima} min. ${bpMsg}`;
     }
   }
 
-  const ore_eff_bp = uscita_bp - ingresso - pausa;
+  const ore_eff_bp = uscita_bp - ingresso - pausaEff;
 
   return {
     tipo,
@@ -140,7 +152,7 @@ function aggiornaRisultati() {
       <div class="title">${tipoGiornata.charAt(0).toUpperCase() + tipoGiornata.slice(1)} <span>${result.badge}</span></div>
       <div class="time">🕓 Uscita per BP: ${result.uscita_stimata}</div>
       <div class="time">🎯 Uscita Strategica: ${result.uscita_strategica}</div>
-      <div class="time">🍽️ Pausa: ${result.pausa_inizio} - ${result.pausa_fine}</div>
+      <div class="time">🍽️ Orario pausa suggerita: ${result.pausa_inizio} - ${result.pausa_fine}</div>
       <div class="time">💡 ${result.suggerimento}</div>
     </div>
   `;
@@ -242,9 +254,9 @@ function initSettings() {
   });
 
   save.addEventListener('click', () => {
-    settings.extraCorta = parseInt(extra.value) || 0;
-    settings.recuperoLunga = parseInt(rec.value) || 0;
-    settings.pausaMinima = parseInt(pausa.value) || 0;
+    settings.extraCorta = Math.min(Math.max(parseInt(extra.value) || 0, 0), 30);
+    settings.recuperoLunga = Math.min(Math.max(parseInt(rec.value) || 0, 0), 30);
+    settings.pausaMinima = Math.min(Math.max(parseInt(pausa.value) || 0, 20), 120);
     saveSettings();
     panel.hidden = true;
     aggiornaRisultati();
@@ -282,7 +294,7 @@ function testStrategico() {
   console.group("🔍 Test calcolaGiornata()");
   const r1 = calcolaGiornata("corta", timeToMinutes("09:32"));
   console.assert(r1.uscita_stimata.startsWith("16:03"), "❌ Test 1 stimata: expected 16:03");
-  console.assert(r1.uscita_strategica.startsWith("16:22") === false, "✅ Test 2 strategica: acc e rec superano 29 min, ridotto");
+  console.assert(r1.uscita_strategica.startsWith("16:22") === false, "✅ Test 2 strategica: acc e rec superano 30 min, ridotto");
 
   const r2 = calcolaGiornata("lunga", timeToMinutes("11:49"));
   console.assert(r2.uscita_strategica <= "19:30", "❌ Test 3: limite orario massimo superato");

--- a/style.css
+++ b/style.css
@@ -186,6 +186,10 @@ input:checked + .slider:before {
   justify-content: center;
 }
 
+.settings-panel[hidden] {
+  display: none;
+}
+
 .settings-content {
   background: #fff;
   padding: 20px;


### PR DESCRIPTION
## Summary
- restrict lunch break input in settings
- clamp pausaMinima when loading and saving
- account for minimum and maximum break in calculations and tips
- document core calculation rules


------
https://chatgpt.com/codex/tasks/task_e_6863d0da3b60832aa802ad015663cdea